### PR TITLE
remove json.stringify which causes errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,7 @@ module.exports = function (scope, options, nodeList) {
 }
 
 module.exports = function canStacheLoader(source) {
-    const src = JSON.stringify(source);
-
     const intermediateAndImports = getIntermediateAndImports(source);
 
-    return getTemplate(src, intermediateAndImports.imports);
+    return getTemplate(source, intermediateAndImports.imports);
 };

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
-const getIntermediateAndImports = require('./intermediate_and_imports');
-// const getIntermediateAndImports = require('can-stache/src/intermediate_and_imports');
-// const getIntermediateAndImports = require('can/dist/cjs/view/stache/intermediate_and_imports');
+const getIntermediateAndImports = require("can-stache/src/intermediate_and_imports");
 
 
 const getTemplate = (source, imports) => {
   const requires = imports.map(i => `require('${i}');`).join('\n');
 
-  return `var stache = require('can/dist/cjs/view/stache/stache');
-var mustacheCore = require('can/dist/cjs/view/stache/mustache_core');
-var getIntermediateAndImports = require('can/dist/cjs/view/stache/intermediate_and_imports');
+  return `var stache = require('can-stache');
+var mustacheCore = require('can-stache/src/mustache_core');
+var getIntermediateAndImports = require("can-stache/src/intermediate_and_imports");
 
 ${requires}
 
@@ -20,17 +18,18 @@ var renderer = stache(intermediate);
 
 module.exports = function (scope, options, nodeList) {
     var moduleOptions = { module: module };
-    
+
     if (!(options instanceof mustacheCore.Options)) {
         options = new mustacheCore.Options(options || {});
     }
-    
+
     return renderer(scope, options.add(moduleOptions), nodeList);
 };`;
 }
 
 module.exports = function canStacheLoader(source) {
-    const intermediateAndImports = getIntermediateAndImports(source);
 
-    return getTemplate(source, intermediateAndImports.imports);
+  const intermediateAndImports = getIntermediateAndImports(source);
+
+  return getTemplate(source, intermediateAndImports.imports);
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "mustache"
   ],
   "dependencies": {
-    "can": "^2.3.31",
     "can-stache": "^3.0.25",
     "can-view-parser": "^3.3.0"
   },


### PR DESCRIPTION
The json.stringify makes the code fail when using webpack 3 with canjs 3.x. Not sure its even necessary for 2.x.

For instance if I have a component with this:

```html
<p class="hello"><content /></p>
```

The output looks like this:
`<p class=\\\\"hello\\\\"><content /></p>`